### PR TITLE
Expose header actions on mobile view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,7 +138,7 @@ export default async function Home() {
               Photo desk
             </Link>
           </nav>
-          <div className="hidden items-center gap-3 text-sm md:flex">
+          <div className="flex items-center gap-3 text-sm">
             <Link className="text-slate-400 hover:text-slate-100" href="/login">
               Sign in
             </Link>


### PR DESCRIPTION
## Summary
- show the sign-in link and subscribe modal trigger on small screens by keeping the header actions visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d78c06494883219a22a342c029e783