### PR TITLE
Make subscribe modal responsive across viewports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,7 +138,7 @@ export default async function Home() {
               Photo desk
             </Link>
           </nav>
-          <div className="hidden items-center gap-3 text-sm md:flex">
+          <div className="flex items-center gap-3 text-sm">
             <Link className="text-slate-400 hover:text-slate-100" href="/login">
               Sign in
             </Link>

--- a/src/components/subscribe-modal.tsx
+++ b/src/components/subscribe-modal.tsx
@@ -94,9 +94,9 @@ export function SubscribeModal() {
       </button>
 
       {isOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto px-4 py-6 sm:items-center sm:py-12">
           <div className="absolute inset-0 bg-slate-950/80 backdrop-blur-sm" onClick={() => setIsOpen(false)} />
-          <div className="relative w-full max-w-md overflow-hidden rounded-3xl border border-slate-800 bg-slate-900 p-8 shadow-[0_30px_120px_rgba(15,23,42,0.55)]">
+          <div className="relative w-full max-w-md rounded-3xl border border-slate-800 bg-slate-900 shadow-[0_30px_120px_rgba(15,23,42,0.55)]">
             <button
               type="button"
               onClick={() => setIsOpen(false)}
@@ -107,7 +107,7 @@ export function SubscribeModal() {
             </button>
 
             {stage === "idle" ? (
-              <form className="space-y-6" onSubmit={onSubmit}>
+              <form className="max-h-[min(90vh,34rem)] space-y-6 overflow-y-auto p-6 sm:p-8" onSubmit={onSubmit}>
                 <div className="space-y-2">
                   <h2 className="text-xl font-semibold text-white">Stay ahead of the narrative</h2>
                   <p className="text-sm text-slate-400">
@@ -160,7 +160,7 @@ export function SubscribeModal() {
                 </button>
               </form>
             ) : (
-              <div className="relative space-y-5 text-center">
+              <div className="relative max-h-[min(90vh,34rem)] space-y-5 overflow-y-auto p-6 text-center sm:p-8">
                 <div className="relative mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-indigo-500/10">
                   <span className="text-3xl">🎉</span>
                 </div>


### PR DESCRIPTION
## Summary
- allow the subscription modal overlay to scroll so the form stays fully visible on small screens
- constrain the modal content height and padding so it no longer clips on desktop displays

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d78c06494883219a22a342c029e783